### PR TITLE
Refactor: MSW + faker.js 기반 mock 서버 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^44.3.0",
         "@ckeditor/ckeditor5-react": "^9.5.0",
+        "@faker-js/faker": "^9.9.0",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tanstack/react-query": "^5.76.1",
         "axios": "^1.9.0",
@@ -17,6 +18,7 @@
         "date-fns": "^4.1.0",
         "html-react-parser": "^5.2.5",
         "lodash": "^4.17.21",
+        "msw": "^2.10.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.6.1",
@@ -395,6 +397,43 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+      "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/tough-cookie": "^4.0.5",
+        "tough-cookie": "^4.1.4"
       }
     },
     "node_modules/@chromatic-com/storybook": {
@@ -13154,6 +13193,22 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@faker-js/faker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -13218,6 +13273,126 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.15.tgz",
+      "integrity": "sha512-SwHMGa8Z47LawQN0rog0sT+6JpiL0B7eW9p1Bb7iCeKDGTI5Ez25TSc2l8kw52VV7hA4sX/C78CGkMrKXfuspA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -13343,6 +13518,23 @@
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.6.tgz",
+      "integrity": "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -13390,6 +13582,28 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -14785,6 +14999,12 @@
       "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==",
       "license": "MIT"
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -14852,7 +15072,7 @@
       "version": "22.15.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
       "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -14893,6 +15113,18 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
     },
     "node_modules/@types/turndown": {
@@ -15753,6 +15985,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -16991,6 +17250,78 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -17729,7 +18060,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18520,6 +18850,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -18708,6 +19047,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -18798,6 +19146,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "license": "MIT"
     },
     "node_modules/html-dom-parser": {
       "version": "5.1.1",
@@ -19222,6 +19576,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -19884,6 +20244,71 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.10.5.tgz",
+      "integrity": "sha512-0EsQCrCI1HbhpBWd89DvmxY6plmvrM96b0sCIztnvcNHQbXn5vqwm1KlXslo6u4wN9LFGLC1WFjjgljcQhe40A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.39.1",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -20140,6 +20565,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -20274,6 +20705,12 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -20719,15 +21156,32 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -21170,6 +21624,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -21618,6 +22087,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -21696,6 +22174,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -22178,6 +22662,30 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -22380,7 +22888,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -22436,7 +22944,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -22537,6 +23045,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util": {
@@ -23117,6 +23635,15 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -23136,6 +23663,65 @@
         "node": ">= 14.6"
       }
     },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -23144,6 +23730,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^44.3.0",
     "@ckeditor/ckeditor5-react": "^9.5.0",
+    "@faker-js/faker": "^9.9.0",
     "@tailwindcss/line-clamp": "^0.4.4",
     "@tanstack/react-query": "^5.76.1",
     "axios": "^1.9.0",
@@ -21,6 +22,7 @@
     "date-fns": "^4.1.0",
     "html-react-parser": "^5.2.5",
     "lodash": "^4.17.21",
+    "msw": "^2.10.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.6.1",

--- a/package.json
+++ b/package.json
@@ -81,5 +81,10 @@
     "extends": [
       "plugin:storybook/recommended"
     ]
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,344 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.10.5'
+const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ */
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,10 @@
+import { worker } from "@/mocks/browser.ts";
+
+await worker.start({
+  serviceWorker: { url: "/mockServiceWorker.js" },
+  onUnhandledRequest: "bypass", // 등록 안 된 요청은 에러 발생
+});
+
 import "@/shared/styles/index.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from "msw/browser";
+import { handlers } from "@/mocks/handlers";
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/data/Memorial.ts
+++ b/src/mocks/data/Memorial.ts
@@ -3,7 +3,7 @@ import type { DonorData, DonorListResponse } from "@/shared/types/remembrance/Do
 import type { ApiResponse } from "@/shared/api/common/types";
 import type { MemberDetail, MemberDetailResponse } from "@/shared/api/members-view/member/types";
 import type { HeavenLetterPagination } from "@/shared/api/members-view/letter/types";
-import type { CommentPagination } from "@/shared/api/recipient-view/comment/types";
+import type { Comment, CommentPagination } from "@/shared/api/recipient-view/comment/types";
 
 import { format, parseISO } from "date-fns";
 
@@ -149,25 +149,57 @@ export function donorDetailResponse(donateSeq: number): MemberDetailResponse {
   };
 }
 
-// 댓글 페이지네이션 생성 함수
-export function makeCommentPagination(donateSeq: number, size = 3): CommentPagination {
-  const comments = Array.from({ length: size }, () => ({
-    commentSeq: faker.number.int({ min: 1, max: 10000 }),
-    donateSeq,
-    commentWriter: faker.person.fullName(),
-    contents: faker.lorem.sentence(),
-    writeTime: faker.date.past().toISOString(),
-  }));
+// 기증자별 댓글 풀
+const commentsByDonor = new Map<number, Comment[]>();
 
-  // 최신순 정렬
-  comments.sort((a, b) => new Date(b.writeTime).getTime() - new Date(a.writeTime).getTime());
+function ensureDonorCommentPool(donateSeq: number, poolSize = 10): Comment[] {
+  if (!commentsByDonor.has(donateSeq)) {
+    const pool: Comment[] = Array.from({ length: poolSize }, () => ({
+      commentSeq: faker.number.int({ min: 1, max: 1000000 }),
+      donateSeq, // 기증자 기준
+      commentWriter: faker.person.fullName(),
+      contents: faker.lorem.sentence(),
+      writeTime: faker.date.past().toISOString(),
+    }));
+    // 최신순 고정
+    pool.sort((a, b) => new Date(b.writeTime!).getTime() - new Date(a.writeTime!).getTime());
+    commentsByDonor.set(donateSeq, pool);
+  }
+  return commentsByDonor.get(donateSeq)!;
+}
+
+function sliceDonorCommentsByCursor(
+  donateSeq: number,
+  size = 3,
+  cursorSeq?: number,
+): CommentPagination {
+  const pool = ensureDonorCommentPool(donateSeq);
+
+  let start = 0;
+  if (cursorSeq) {
+    const idx = pool.findIndex((c) => c.commentSeq === cursorSeq);
+    start = idx >= 0 ? idx + 1 : pool.length;
+  }
+
+  const page = pool.slice(start, start + size);
+  const hasNext = start + size < pool.length;
+  const nextCursor = hasNext && page.length ? page.at(-1)!.commentSeq : 0;
 
   return {
-    content: comments,
-    comments,
-    commentNextCursor: 0,
-    commentHasNext: false,
+    content: page,
+    comments: page,
+    commentHasNext: hasNext,
+    commentNextCursor: nextCursor,
   };
+}
+
+// 댓글 페이지네이션 생성 함수
+export function makeCommentPagination(
+  donateSeq: number,
+  size = 3,
+  cursorSeq?: number,
+): CommentPagination {
+  return sliceDonorCommentsByCursor(donateSeq, size, cursorSeq);
 }
 
 // 편지 페이지네이션 생성 함수

--- a/src/mocks/data/Memorial.ts
+++ b/src/mocks/data/Memorial.ts
@@ -19,8 +19,8 @@ const makeDonor = (): DonorData => ({
   genderFlag: faker.helpers.arrayElement(["M", "F"]),
   donateAge: faker.number.int({ min: 1, max: 100 }),
   donateDate: faker.date.past().toISOString().slice(0, 10), // YYYY-MM-DD
-  commentCount: faker.number.int({ min: 0, max: 50 }),
-  letterCount: faker.number.int({ min: 0, max: 50 }),
+  commentCount: faker.number.int({ min: 0, max: 30 }),
+  letterCount: faker.number.int({ min: 0, max: 30 }),
 });
 
 // 2) 전역 데이터셋 300개를 한 번만 생성
@@ -152,8 +152,12 @@ export function donorDetailResponse(donateSeq: number): MemberDetailResponse {
 // 기증자별 댓글 풀
 const commentsByDonor = new Map<number, Comment[]>();
 
-function ensureDonorCommentPool(donateSeq: number, poolSize = 10): Comment[] {
+function ensureDonorCommentPool(donateSeq: number): Comment[] {
   if (!commentsByDonor.has(donateSeq)) {
+    // 목록에서 설정해둔 commentCount 사용
+    const donor = ALL_DONORS.find((d) => d.donateSeq === donateSeq);
+    const poolSize = donor?.commentCount ?? 0; // 없으면 0개
+
     const pool: Comment[] = Array.from({ length: poolSize }, () => ({
       commentSeq: faker.number.int({ min: 1, max: 1000000 }),
       donateSeq, // 기증자 기준

--- a/src/mocks/data/Memorial.ts
+++ b/src/mocks/data/Memorial.ts
@@ -1,0 +1,76 @@
+import { fakerKO as faker } from "@faker-js/faker";
+import type { DonorData, DonorListResponse } from "@/shared/types/remembrance/DonorData.types";
+import type { ApiResponse } from "@/shared/api/common/types";
+
+/** 시드 고정 */
+faker.seed(42);
+
+/** 기증자 목록 조회 데이터 */
+
+// 1) 아이템 생성기
+const makeDonor = (): DonorData => ({
+  donateSeq: faker.number.int({ min: 1, max: 100000 }),
+  donorName: faker.person.fullName(),
+  genderFlag: faker.helpers.arrayElement(["M", "F"]),
+  donateAge: faker.number.int({ min: 1, max: 100 }),
+  donateDate: faker.date.past().toISOString().slice(0, 10), // YYYY-MM-DD
+  commentCount: faker.number.int({ min: 0, max: 50 }),
+  letterCount: faker.number.int({ min: 0, max: 50 }),
+});
+
+// 2) 전역 데이터셋 300개를 한 번만 생성
+const TOTAL = 300;
+export const ALL_DONORS: DonorData[] = Array.from({ length: TOTAL }, makeDonor);
+
+// 3) 날짜 내림차순 → 같은 날짜면 donateSeq 내림차순
+const byDateDesc = (a: DonorData, b: DonorData) => {
+  const ta = new Date(a.donateDate).getTime();
+  const tb = new Date(b.donateDate).getTime();
+  if (ta !== tb) return tb - ta;
+  return b.donateSeq - a.donateSeq;
+};
+
+// 4) 정렬 한 번만 적용
+ALL_DONORS.sort(byDateDesc);
+
+// 5) 커서 기반 페이지 추출
+function slice(size: number, cursor?: { seq: number; date: string }) {
+  let start = 0;
+
+  if (cursor) {
+    // cursor가 가리키는 아이템의 "다음"부터 시작
+    const idx = ALL_DONORS.findIndex(
+      (d) => d.donateSeq === cursor.seq && d.donateDate === cursor.date,
+    );
+    start = idx >= 0 ? idx + 1 : ALL_DONORS.length;
+  }
+
+  const content = ALL_DONORS.slice(start, start + size);
+  const hasNext = start + size < ALL_DONORS.length;
+  const last = content.at(-1);
+  const nextCursor = hasNext && last ? { cursor: last.donateSeq, date: last.donateDate } : null;
+
+  return { content, hasNext, nextCursor, totalCount: ALL_DONORS.length };
+}
+
+// 6) 응답 빌더
+export function donorListResponse(params?: {
+  size?: number;
+  cursorSeq?: number;
+  cursorDate?: string;
+}): ApiResponse<DonorListResponse> {
+  const size = params?.size ?? 30;
+  const cursor =
+    params?.cursorSeq && params?.cursorDate
+      ? { seq: params.cursorSeq, date: params.cursorDate }
+      : undefined;
+
+  const { content, hasNext, nextCursor, totalCount } = slice(size, cursor);
+
+  return {
+    success: true,
+    code: 200,
+    message: "게시글 조회 성공",
+    data: { content, hasNext, nextCursor, totalCount },
+  };
+}

--- a/src/mocks/data/Memorial.ts
+++ b/src/mocks/data/Memorial.ts
@@ -1,18 +1,18 @@
 import { fakerKO as faker } from "@faker-js/faker";
+import { format, parseISO } from "date-fns";
 import type { DonorData, DonorListResponse } from "@/shared/types/remembrance/DonorData.types";
 import type { ApiResponse } from "@/shared/api/common/types";
 import type { MemberDetail, MemberDetailResponse } from "@/shared/api/members-view/member/types";
 import type { HeavenLetterPagination } from "@/shared/api/members-view/letter/types";
 import type { Comment, CommentPagination } from "@/shared/api/recipient-view/comment/types";
-
-import { format, parseISO } from "date-fns";
+import { createCursorPagination, createDateDescSorter } from "@/mocks/utils/paginate";
 
 /** 시드 고정 */
 faker.seed(42);
 
 /** 기증자 목록 조회 데이터 */
 
-// 1) 아이템 생성기
+// 아이템 생성
 const makeDonor = (): DonorData => ({
   donateSeq: faker.number.int({ min: 1, max: 10000 }),
   donorName: faker.person.fullName(),
@@ -23,42 +23,20 @@ const makeDonor = (): DonorData => ({
   letterCount: faker.number.int({ min: 0, max: 30 }),
 });
 
-// 2) 전역 데이터셋 300개를 한 번만 생성
+// 전역 데이터셋 300개를 한 번만 생성
 const TOTAL = 300;
 export const ALL_DONORS: DonorData[] = Array.from({ length: TOTAL }, makeDonor);
 
-// 3) 날짜 내림차순 → 같은 날짜면 donateSeq 내림차순
-const byDateDesc = (a: DonorData, b: DonorData) => {
-  const ta = new Date(a.donateDate).getTime();
-  const tb = new Date(b.donateDate).getTime();
-  if (ta !== tb) return tb - ta;
-  return b.donateSeq - a.donateSeq;
-};
+// 정렬 유틸 사용
+const sorter = createDateDescSorter(
+  (item: DonorData) => item.donateDate,
+  (item: DonorData) => item.donateSeq,
+);
 
-// 4) 정렬 한 번만 적용
-ALL_DONORS.sort(byDateDesc);
+// 정렬 한 번만 적용
+ALL_DONORS.sort(sorter);
 
-// 5) 커서 기반 페이지 추출
-function slice(size: number, cursor?: { seq: number; date: string }) {
-  let start = 0;
-
-  if (cursor) {
-    // cursor가 가리키는 아이템의 "다음"부터 시작
-    const idx = ALL_DONORS.findIndex(
-      (d) => d.donateSeq === cursor.seq && d.donateDate === cursor.date,
-    );
-    start = idx >= 0 ? idx + 1 : ALL_DONORS.length;
-  }
-
-  const content = ALL_DONORS.slice(start, start + size);
-  const hasNext = start + size < ALL_DONORS.length;
-  const last = content.at(-1);
-  const nextCursor = hasNext && last ? { cursor: last.donateSeq, date: last.donateDate } : null;
-
-  return { content, hasNext, nextCursor, totalCount: ALL_DONORS.length };
-}
-
-// 6) 응답 빌더
+// 기증자 목록 응답 - 페이지네이션 유틸 사용
 export function donorListResponse(params?: {
   size?: number;
   cursorSeq?: number;
@@ -70,7 +48,13 @@ export function donorListResponse(params?: {
       ? { seq: params.cursorSeq, date: params.cursorDate }
       : undefined;
 
-  const { content, hasNext, nextCursor, totalCount } = slice(size, cursor);
+  const { content, hasNext, nextCursor, totalCount } = createCursorPagination(
+    ALL_DONORS,
+    size,
+    cursor,
+    (item) => item.donateSeq,
+    (item) => item.donateDate,
+  );
 
   return {
     success: true,

--- a/src/mocks/data/Memorial.ts
+++ b/src/mocks/data/Memorial.ts
@@ -7,6 +7,7 @@ import type { HeavenLetterPagination } from "@/shared/api/members-view/letter/ty
 import type { CommentPagination } from "@/shared/api/recipient-view/comment/types";
 import { createCursorPagination, createDateDescSorter } from "@/mocks/utils/paginate";
 import { commentPoolManager } from "@/mocks/utils/commentPool";
+import { letterPoolManager } from "@/mocks/utils/letterPool";
 
 /** 시드 고정 */
 faker.seed(42);
@@ -154,22 +155,14 @@ export function makeCommentPagination(
   );
 }
 
-// 편지 페이지네이션 생성 함수
-export function makeHeavenLetterPagination(donateSeq: number, size = 3): HeavenLetterPagination {
-  const letters = Array.from({ length: size }, () => ({
-    letterSeq: faker.number.int({ min: 1, max: 10000 }),
-    letterTitle: faker.lorem.words(3),
-    readCount: faker.number.int({ min: 0, max: 100 }),
-    writeTime: faker.date.past().toISOString().slice(0, 10),
-  }));
+// 기증자별 편지 풀 유틸 사용
+export function makeHeavenLetterPagination(
+  donateSeq: number,
+  size = 3,
+  cursorSeq?: number,
+): HeavenLetterPagination {
+  const donor = ALL_DONORS.find((d) => d.donateSeq === donateSeq);
+  const poolSize = donor?.letterCount ?? 0;
 
-  // 최신순
-  letters.sort((a, b) => new Date(b.writeTime).getTime() - new Date(a.writeTime).getTime());
-
-  return {
-    content: letters,
-    nextCursor: 0,
-    hasNext: false,
-    totalCount: size,
-  };
+  return letterPoolManager.createAndSlice(donateSeq, poolSize, size, cursorSeq);
 }

--- a/src/mocks/data/Memorial.ts
+++ b/src/mocks/data/Memorial.ts
@@ -4,8 +4,9 @@ import type { DonorData, DonorListResponse } from "@/shared/types/remembrance/Do
 import type { ApiResponse } from "@/shared/api/common/types";
 import type { MemberDetail, MemberDetailResponse } from "@/shared/api/members-view/member/types";
 import type { HeavenLetterPagination } from "@/shared/api/members-view/letter/types";
-import type { Comment, CommentPagination } from "@/shared/api/recipient-view/comment/types";
+import type { CommentPagination } from "@/shared/api/recipient-view/comment/types";
 import { createCursorPagination, createDateDescSorter } from "@/mocks/utils/paginate";
+import { commentPoolManager } from "@/mocks/utils/commentPool";
 
 /** 시드 고정 */
 faker.seed(42);
@@ -133,61 +134,24 @@ export function donorDetailResponse(donateSeq: number): MemberDetailResponse {
   };
 }
 
-// 기증자별 댓글 풀
-const commentsByDonor = new Map<number, Comment[]>();
-
-function ensureDonorCommentPool(donateSeq: number): Comment[] {
-  if (!commentsByDonor.has(donateSeq)) {
-    // 목록에서 설정해둔 commentCount 사용
-    const donor = ALL_DONORS.find((d) => d.donateSeq === donateSeq);
-    const poolSize = donor?.commentCount ?? 0; // 없으면 0개
-
-    const pool: Comment[] = Array.from({ length: poolSize }, () => ({
-      commentSeq: faker.number.int({ min: 1, max: 1000000 }),
-      donateSeq, // 기증자 기준
-      commentWriter: faker.person.fullName(),
-      contents: faker.lorem.sentence(),
-      writeTime: faker.date.past().toISOString(),
-    }));
-    // 최신순 고정
-    pool.sort((a, b) => new Date(b.writeTime!).getTime() - new Date(a.writeTime!).getTime());
-    commentsByDonor.set(donateSeq, pool);
-  }
-  return commentsByDonor.get(donateSeq)!;
-}
-
-function sliceDonorCommentsByCursor(
-  donateSeq: number,
-  size = 3,
-  cursorSeq?: number,
-): CommentPagination {
-  const pool = ensureDonorCommentPool(donateSeq);
-
-  let start = 0;
-  if (cursorSeq) {
-    const idx = pool.findIndex((c) => c.commentSeq === cursorSeq);
-    start = idx >= 0 ? idx + 1 : pool.length;
-  }
-
-  const page = pool.slice(start, start + size);
-  const hasNext = start + size < pool.length;
-  const nextCursor = hasNext && page.length ? page.at(-1)!.commentSeq : 0;
-
-  return {
-    content: page,
-    comments: page,
-    commentHasNext: hasNext,
-    commentNextCursor: nextCursor,
-  };
-}
-
-// 댓글 페이지네이션 생성 함수
+// 기증자별 댓글 풀 유틸 사용
 export function makeCommentPagination(
   donateSeq: number,
   size = 3,
   cursorSeq?: number,
 ): CommentPagination {
-  return sliceDonorCommentsByCursor(donateSeq, size, cursorSeq);
+  // 목록에서 설정해둔 commentCount 사용
+  const donor = ALL_DONORS.find((d) => d.donateSeq === donateSeq);
+  const poolSize = donor?.commentCount ?? 0;
+
+  return commentPoolManager.createAndSlice(
+    `donor-${donateSeq}`,
+    poolSize,
+    "donateSeq",
+    donateSeq,
+    size,
+    cursorSeq,
+  );
 }
 
 // 편지 페이지네이션 생성 함수

--- a/src/mocks/data/Memorial.ts
+++ b/src/mocks/data/Memorial.ts
@@ -1,6 +1,11 @@
 import { fakerKO as faker } from "@faker-js/faker";
 import type { DonorData, DonorListResponse } from "@/shared/types/remembrance/DonorData.types";
 import type { ApiResponse } from "@/shared/api/common/types";
+import type { MemberDetail, MemberDetailResponse } from "@/shared/api/members-view/member/types";
+import type { HeavenLetterPagination } from "@/shared/api/members-view/letter/types";
+import type { CommentPagination } from "@/shared/api/recipient-view/comment/types";
+
+import { format, parseISO } from "date-fns";
 
 /** 시드 고정 */
 faker.seed(42);
@@ -9,7 +14,7 @@ faker.seed(42);
 
 // 1) 아이템 생성기
 const makeDonor = (): DonorData => ({
-  donateSeq: faker.number.int({ min: 1, max: 100000 }),
+  donateSeq: faker.number.int({ min: 1, max: 10000 }),
   donorName: faker.person.fullName(),
   genderFlag: faker.helpers.arrayElement(["M", "F"]),
   donateAge: faker.number.int({ min: 1, max: 100 }),
@@ -72,5 +77,115 @@ export function donorListResponse(params?: {
     code: 200,
     message: "게시글 조회 성공",
     data: { content, hasNext, nextCursor, totalCount },
+  };
+}
+
+/** 기증자 상세 조회 데이터 */
+
+// 추모 메세지 템플릿 (데모용)
+function tributeMessage(donor: DonorData): string {
+  const genderText = donor.genderFlag === "F" ? "여" : "남";
+  const ageText = donor.donateAge ? `(${genderText},${donor.donateAge})` : "";
+  const donateDate = format(parseISO(donor.donateDate), "yyyy.MM.dd");
+
+  return `
+    <p>${donor.donorName} 님 ${ageText}은 ${donateDate} 환자들에게 귀중한 장기를 선물해 주셨습니다.</p>
+    <p>한국장기조직기증원은 귀한 생명을 나눠주신 기증자와 유가족께 깊이 감사드리며, </p>
+    <p>앞으로도 기증자 유가족들이 건강한 삶을 유지할 수 있도록 최선을 다해 지원할 것입니다.</p>
+    <p>고인의 명복을 빕니다.</p>
+  `;
+}
+
+// 상세 정보 생성 함수
+export function makeDonorDetail(donateSeq: number): MemberDetail {
+  const donor = ALL_DONORS.find((d) => d.donateSeq === donateSeq);
+  if (!donor) throw new Error("기증자 없음");
+  return {
+    donateSeq: donor.donateSeq,
+    donorName: donor.donorName,
+    donateTitle: faker.lorem.words(2),
+    contents: tributeMessage(donor),
+    fileName: null,
+    orgFileName: null,
+    writer: faker.person.fullName(),
+    donateDate: donor.donateDate,
+    genderFlag: donor.genderFlag ?? "M",
+    donateAge: donor.donateAge ?? 0,
+
+    // 이모지 카운트
+    flowerCount: faker.number.int({ min: 0, max: 100 }),
+    loveCount: faker.number.int({ min: 0, max: 100 }),
+    seeCount: faker.number.int({ min: 0, max: 100 }),
+    missCount: faker.number.int({ min: 0, max: 100 }),
+    proudCount: faker.number.int({ min: 0, max: 100 }),
+    hardCount: faker.number.int({ min: 0, max: 100 }),
+    sadCount: faker.number.int({ min: 0, max: 100 }),
+
+    writeTime: faker.date.past().toISOString(),
+
+    // 페이지네이션
+    memorialCommentResponses: makeCommentPagination(donor.donateSeq, 3),
+    heavenLetterResponses: makeHeavenLetterPagination(donor.donateSeq, 3),
+  };
+}
+
+// 캐싱
+const DETAIL_CACHE = new Map<number, MemberDetail>();
+
+export function getDonorDetail(donateSeq: number): MemberDetail {
+  if (!DETAIL_CACHE.has(donateSeq)) {
+    DETAIL_CACHE.set(donateSeq, makeDonorDetail(donateSeq));
+  }
+  return DETAIL_CACHE.get(donateSeq)!;
+}
+
+// 응답
+export function donorDetailResponse(donateSeq: number): MemberDetailResponse {
+  return {
+    success: true,
+    code: 200,
+    message: "기증자 상세 조회 성공",
+    data: getDonorDetail(donateSeq),
+  };
+}
+
+// 댓글 페이지네이션 생성 함수
+export function makeCommentPagination(donateSeq: number, size = 3): CommentPagination {
+  const comments = Array.from({ length: size }, () => ({
+    commentSeq: faker.number.int({ min: 1, max: 10000 }),
+    donateSeq,
+    commentWriter: faker.person.fullName(),
+    contents: faker.lorem.sentence(),
+    writeTime: faker.date.past().toISOString(),
+  }));
+
+  // 최신순 정렬
+  comments.sort((a, b) => new Date(b.writeTime).getTime() - new Date(a.writeTime).getTime());
+
+  return {
+    content: comments,
+    comments,
+    commentNextCursor: 0,
+    commentHasNext: false,
+  };
+}
+
+// 편지 페이지네이션 생성 함수
+export function makeHeavenLetterPagination(donateSeq: number, size = 3): HeavenLetterPagination {
+  const letters = Array.from({ length: size }, () => ({
+    letterSeq: faker.number.int({ min: 1, max: 10000 }),
+    letterTitle: faker.lorem.words(3),
+    readCount: faker.number.int({ min: 0, max: 100 }),
+    writeTime: faker.date.past().toISOString().slice(0, 10),
+  }));
+
+  // 최신순
+  letters.sort((a, b) => new Date(b.writeTime).getTime() - new Date(a.writeTime).getTime());
+
+  return {
+    content: letters,
+    nextCursor: 0,
+    hasNext: false,
+    totalCount: size,
   };
 }

--- a/src/mocks/data/heaven.ts
+++ b/src/mocks/data/heaven.ts
@@ -1,44 +1,73 @@
 import { fakerKO as faker } from "@faker-js/faker";
 import type { ApiResponse } from "@/shared/api/common/types";
-import type { CommentPagination } from "@/shared/api/recipient-view/comment/types";
 import type {
   HeavenLetterDetail,
   HeavenLetterDetailResponse,
 } from "@/shared/api/letter-view/letter/types";
+import type { Comment, CommentPagination } from "@/shared/api/recipient-view/comment/types";
 
-//시드 고정
+// 시드 고정
 faker.seed(42);
 
-/** 전역 데이터: HeavenLetterDetail[] 만 사용 (새 타입 없음) */
+/** 전역 데이터: HeavenLetterDetail[] 만 사용 */
 const TOTAL = 300;
 
-function makeCommentPaginationForLetter(size = 3): CommentPagination {
-  const comments = Array.from({ length: size }, () => ({
-    commentSeq: faker.number.int({ min: 1, max: 10000 }),
-    donateSeq: 0,
-    commentWriter: faker.person.fullName(),
-    contents: faker.lorem.sentences({ min: 1, max: 3 }),
-    writeTime: faker.date.past().toISOString(),
-  }));
+/** 댓글 풀 + 슬라이스 */
+const commentsByLetter = new Map<number, Comment[]>();
 
-  comments.sort((a, b) => new Date(b.writeTime).getTime() - new Date(a.writeTime).getTime());
+function LetterCommentPool(letterSeq: number, poolSize = 80): Comment[] {
+  if (!commentsByLetter.has(letterSeq)) {
+    const pool: Comment[] = Array.from({ length: poolSize }, () => ({
+      commentSeq: faker.number.int({ min: 1, max: 1000000 }),
+      letterSeq, // 편지 기준
+      commentWriter: faker.person.fullName(),
+      contents: faker.lorem.sentences({ min: 1, max: 3 }),
+      writeTime: faker.date.past().toISOString(),
+    })).sort((a, b) => new Date(b.writeTime!).getTime() - new Date(a.writeTime!).getTime());
+    commentsByLetter.set(letterSeq, pool);
+  }
+  return commentsByLetter.get(letterSeq)!;
+}
+
+function sliceLetterComments(letterSeq: number, size = 3, cursorSeq?: number): CommentPagination {
+  const pool = LetterCommentPool(letterSeq);
+
+  let start = 0;
+  if (cursorSeq) {
+    const idx = pool.findIndex((c) => c.commentSeq === cursorSeq);
+    start = idx >= 0 ? idx + 1 : pool.length;
+  }
+
+  const page = pool.slice(start, start + size);
+  const hasNext = start + size < pool.length;
+  const nextCursor = hasNext && page.length ? page.at(-1)!.commentSeq : 0;
 
   return {
-    content: comments,
-    comments,
-    commentNextCursor: 0,
-    commentHasNext: false,
+    content: page,
+    comments: page,
+    commentHasNext: hasNext,
+    commentNextCursor: nextCursor,
   };
 }
 
-function makeHeavenLetterDetail(seq?: number): HeavenLetterDetail {
+/** 커서 기반 */
+export function commentPagination(
+  letterSeq: number,
+  size = 3,
+  cursorSeq?: number,
+): CommentPagination {
+  return sliceLetterComments(letterSeq, size, cursorSeq);
+}
+
+/* ------------------------- 편지 상세 생성 ------------------------- */
+function heavenLetterDetail(seq?: number): HeavenLetterDetail {
   const writeDt = faker.date.past();
   const anonymityFlag = faker.helpers.arrayElement<"Y" | "N">(["Y", "N"]);
   const donorName = faker.person.fullName();
   const writerName = anonymityFlag === "Y" ? "익명" : faker.person.fullName();
 
-  const letterSeq = seq ?? faker.number.int({ min: 1, max: 1_000_000 });
-  const donateSeq = faker.number.int({ min: 1, max: 10_000 });
+  const letterSeq = seq ?? faker.number.int({ min: 1, max: 1000000 });
+  const donateSeq = faker.number.int({ min: 1, max: 10000 });
 
   return {
     letterSeq,
@@ -58,16 +87,19 @@ function makeHeavenLetterDetail(seq?: number): HeavenLetterDetail {
         : "",
     orgFileName: Math.random() < 0.2 ? `원본_${letterSeq}.jpg` : "",
     writeTime: writeDt.toISOString().slice(0, 10),
-    cursorCommentPaginationResponse: makeCommentPaginationForLetter(3),
+
+    // 초기 댓글 페이지 (cursor 없음)
+    cursorCommentPaginationResponse: commentPagination(letterSeq, 3),
   };
 }
 
+/* ---------- 목록/정렬/커서 페이징 (기존 유지) ---------- */
 /** 한 번만 생성해 재사용 */
-export const ALL_HEAVEN_LETTERS: HeavenLetterDetail[] = Array.from({ length: TOTAL }, () =>
-  makeHeavenLetterDetail(),
+export const allHeavenLetters: HeavenLetterDetail[] = Array.from({ length: TOTAL }, () =>
+  heavenLetterDetail(),
 );
 
-/** 정렬: writeTime 내림차순 → 같은 날짜면 letterSeq 내림차순 */
+/** writeTime 내림차순 → 같은 날짜면 letterSeq 내림차순 */
 const byWriteDesc = (a: HeavenLetterDetail, b: HeavenLetterDetail) => {
   const ta = new Date(a.writeTime).getTime();
   const tb = new Date(b.writeTime).getTime();
@@ -75,31 +107,31 @@ const byWriteDesc = (a: HeavenLetterDetail, b: HeavenLetterDetail) => {
   return b.letterSeq - a.letterSeq;
 };
 
-ALL_HEAVEN_LETTERS.sort(byWriteDesc);
+allHeavenLetters.sort(byWriteDesc);
 
-/** 커서 페이징 (Memorial.ts와 동일 규칙: date(YYYY-MM-DD) + seq) */
+/** 커서 페이징 (편지 목록용) */
 function sliceByCursor(
   size: number,
   cursor?: { seq: number; date: string }, // date는 YYYY-MM-DD
 ) {
   let start = 0;
   if (cursor) {
-    const idx = ALL_HEAVEN_LETTERS.findIndex(
+    const idx = allHeavenLetters.findIndex(
       (d) => d.letterSeq === cursor.seq && d.writeTime.slice(0, 10) === cursor.date,
     );
-    start = idx >= 0 ? idx + 1 : ALL_HEAVEN_LETTERS.length;
+    start = idx >= 0 ? idx + 1 : allHeavenLetters.length;
   }
 
-  const window = ALL_HEAVEN_LETTERS.slice(start, start + size);
-  const hasNext = start + size < ALL_HEAVEN_LETTERS.length;
+  const window = allHeavenLetters.slice(start, start + size);
+  const hasNext = start + size < allHeavenLetters.length;
   const last = window.at(-1);
   const nextCursor =
     hasNext && last ? { cursor: last.letterSeq, date: last.writeTime.slice(0, 10) } : null;
 
-  return { window, hasNext, nextCursor, totalCount: ALL_HEAVEN_LETTERS.length };
+  return { window, hasNext, nextCursor, totalCount: allHeavenLetters.length };
 }
 
-/** 목록 응답: LetterCardData[] 로 바로 내려줌 (추가 타입 없음) */
+/** 목록 응답: LetterCardData[] 로 바로 내려줌 */
 export function heavenLetterListResponse(params?: {
   size?: number;
   cursorSeq?: number;
@@ -126,12 +158,11 @@ export function heavenLetterListResponse(params?: {
 
   const { window, hasNext, nextCursor, totalCount } = sliceByCursor(size, cursor);
 
-  // 목록은 원시 필드 그대로 내려줌 (UI 매퍼에서 LetterCardData로 변환)
   const items = window.map((d) => ({
     letterSeq: d.letterSeq,
     donateSeq: d.donateSeq,
     donorName: d.donorName,
-    letterWriter: d.letterWriter, // ← "추모자" 표시에 필요
+    letterWriter: d.letterWriter,
     letterTitle: d.letterTitle,
     readCount: d.readCount,
     writeTime: d.writeTime.slice(0, 10), // YYYY-MM-DD
@@ -145,29 +176,43 @@ export function heavenLetterListResponse(params?: {
   };
 }
 
-/** 상세: HeavenLetterDetail 그대로 사용 (캐시 포함) */
+/** 상세: HeavenLetterDetail 그대로 사용 */
 const DETAIL_CACHE = new Map<number, HeavenLetterDetail>();
 
 export function getHeavenLetterDetail(letterSeq: number): HeavenLetterDetail {
   if (DETAIL_CACHE.has(letterSeq)) return DETAIL_CACHE.get(letterSeq)!;
 
-  // 목록에서 찾고, 없으면 새로 생성해서 합류
-  let found = ALL_HEAVEN_LETTERS.find((d) => d.letterSeq === letterSeq);
+  // 목록에서 찾고, 없으면 새로 생성
+  let found = allHeavenLetters.find((d) => d.letterSeq === letterSeq);
   if (!found) {
-    found = makeHeavenLetterDetail(letterSeq);
-    ALL_HEAVEN_LETTERS.push(found);
-    ALL_HEAVEN_LETTERS.sort(byWriteDesc);
+    found = heavenLetterDetail(letterSeq);
+    allHeavenLetters.push(found);
+    allHeavenLetters.sort(byWriteDesc);
   }
 
   DETAIL_CACHE.set(letterSeq, found);
   return found;
 }
 
-export function heavenLetterDetailResponse(letterSeq: number): HeavenLetterDetailResponse {
+export function heavenLetterDetailResponse(
+  letterSeq: number,
+  opts?: { commentSize?: number; commentCursor?: number },
+): HeavenLetterDetailResponse {
+  const base = getHeavenLetterDetail(letterSeq); // 캐시된 상세 가져오기
+
+  const size = opts?.commentSize ?? 3;
+  const cursor = opts?.commentCursor;
+
+  // 댓글 페이지네이션은 항상 새로 계산해서 내려줌
+  const withComments: HeavenLetterDetail = {
+    ...base,
+    cursorCommentPaginationResponse: commentPagination(letterSeq, size, cursor),
+  };
+
   return {
     success: true,
     code: 200,
     message: "하늘나라 편지 상세 조회 성공",
-    data: getHeavenLetterDetail(letterSeq),
+    data: withComments,
   };
 }

--- a/src/mocks/data/heaven.ts
+++ b/src/mocks/data/heaven.ts
@@ -1,0 +1,173 @@
+import { fakerKO as faker } from "@faker-js/faker";
+import type { ApiResponse } from "@/shared/api/common/types";
+import type { CommentPagination } from "@/shared/api/recipient-view/comment/types";
+import type {
+  HeavenLetterDetail,
+  HeavenLetterDetailResponse,
+} from "@/shared/api/letter-view/letter/types";
+
+//시드 고정
+faker.seed(42);
+
+/** 전역 데이터: HeavenLetterDetail[] 만 사용 (새 타입 없음) */
+const TOTAL = 300;
+
+function makeCommentPaginationForLetter(size = 3): CommentPagination {
+  const comments = Array.from({ length: size }, () => ({
+    commentSeq: faker.number.int({ min: 1, max: 10000 }),
+    donateSeq: 0,
+    commentWriter: faker.person.fullName(),
+    contents: faker.lorem.sentences({ min: 1, max: 3 }),
+    writeTime: faker.date.past().toISOString(),
+  }));
+
+  comments.sort((a, b) => new Date(b.writeTime).getTime() - new Date(a.writeTime).getTime());
+
+  return {
+    content: comments,
+    comments,
+    commentNextCursor: 0,
+    commentHasNext: false,
+  };
+}
+
+function makeHeavenLetterDetail(seq?: number): HeavenLetterDetail {
+  const writeDt = faker.date.past();
+  const anonymityFlag = faker.helpers.arrayElement<"Y" | "N">(["Y", "N"]);
+  const donorName = faker.person.fullName();
+  const writerName = anonymityFlag === "Y" ? "익명" : faker.person.fullName();
+
+  const letterSeq = seq ?? faker.number.int({ min: 1, max: 1_000_000 });
+  const donateSeq = faker.number.int({ min: 1, max: 10_000 });
+
+  return {
+    letterSeq,
+    donateSeq,
+    donorName,
+    letterTitle: faker.lorem.words({ min: 2, max: 6 }),
+    letterWriter: writerName,
+    anonymityFlag,
+    readCount: faker.number.int({ min: 0, max: 100 }),
+    letterContents: `
+      <p>${faker.lorem.paragraphs({ min: 2, max: 5 }).replace(/\n/g, "</p><p>")}</p>
+    `,
+    // 30% 확률로 이미지 붙이기
+    fileName:
+      Math.random() < 0.3
+        ? faker.image.urlLoremFlickr({ width: 640, height: 480, category: "nature" })
+        : "",
+    orgFileName: Math.random() < 0.2 ? `원본_${letterSeq}.jpg` : "",
+    writeTime: writeDt.toISOString().slice(0, 10),
+    cursorCommentPaginationResponse: makeCommentPaginationForLetter(3),
+  };
+}
+
+/** 한 번만 생성해 재사용 */
+export const ALL_HEAVEN_LETTERS: HeavenLetterDetail[] = Array.from({ length: TOTAL }, () =>
+  makeHeavenLetterDetail(),
+);
+
+/** 정렬: writeTime 내림차순 → 같은 날짜면 letterSeq 내림차순 */
+const byWriteDesc = (a: HeavenLetterDetail, b: HeavenLetterDetail) => {
+  const ta = new Date(a.writeTime).getTime();
+  const tb = new Date(b.writeTime).getTime();
+  if (ta !== tb) return tb - ta;
+  return b.letterSeq - a.letterSeq;
+};
+
+ALL_HEAVEN_LETTERS.sort(byWriteDesc);
+
+/** 커서 페이징 (Memorial.ts와 동일 규칙: date(YYYY-MM-DD) + seq) */
+function sliceByCursor(
+  size: number,
+  cursor?: { seq: number; date: string }, // date는 YYYY-MM-DD
+) {
+  let start = 0;
+  if (cursor) {
+    const idx = ALL_HEAVEN_LETTERS.findIndex(
+      (d) => d.letterSeq === cursor.seq && d.writeTime.slice(0, 10) === cursor.date,
+    );
+    start = idx >= 0 ? idx + 1 : ALL_HEAVEN_LETTERS.length;
+  }
+
+  const window = ALL_HEAVEN_LETTERS.slice(start, start + size);
+  const hasNext = start + size < ALL_HEAVEN_LETTERS.length;
+  const last = window.at(-1);
+  const nextCursor =
+    hasNext && last ? { cursor: last.letterSeq, date: last.writeTime.slice(0, 10) } : null;
+
+  return { window, hasNext, nextCursor, totalCount: ALL_HEAVEN_LETTERS.length };
+}
+
+/** 목록 응답: LetterCardData[] 로 바로 내려줌 (추가 타입 없음) */
+export function heavenLetterListResponse(params?: {
+  size?: number;
+  cursorSeq?: number;
+  cursorDate?: string; // YYYY-MM-DD
+}): ApiResponse<{
+  content: Array<{
+    letterSeq: number;
+    donateSeq: number;
+    donorName: string;
+    letterWriter: string;
+    letterTitle: string;
+    readCount: number;
+    writeTime: string; // YYYY-MM-DD
+  }>;
+  hasNext: boolean;
+  nextCursor: { cursor: number; date: string } | null;
+  totalCount: number;
+}> {
+  const size = params?.size ?? 30;
+  const cursor =
+    params?.cursorSeq && params?.cursorDate
+      ? { seq: params.cursorSeq, date: params.cursorDate }
+      : undefined;
+
+  const { window, hasNext, nextCursor, totalCount } = sliceByCursor(size, cursor);
+
+  // 목록은 원시 필드 그대로 내려줌 (UI 매퍼에서 LetterCardData로 변환)
+  const items = window.map((d) => ({
+    letterSeq: d.letterSeq,
+    donateSeq: d.donateSeq,
+    donorName: d.donorName,
+    letterWriter: d.letterWriter, // ← "추모자" 표시에 필요
+    letterTitle: d.letterTitle,
+    readCount: d.readCount,
+    writeTime: d.writeTime.slice(0, 10), // YYYY-MM-DD
+  }));
+
+  return {
+    success: true,
+    code: 200,
+    message: "하늘나라 편지 목록 조회 성공",
+    data: { content: items, hasNext, nextCursor, totalCount },
+  };
+}
+
+/** 상세: HeavenLetterDetail 그대로 사용 (캐시 포함) */
+const DETAIL_CACHE = new Map<number, HeavenLetterDetail>();
+
+export function getHeavenLetterDetail(letterSeq: number): HeavenLetterDetail {
+  if (DETAIL_CACHE.has(letterSeq)) return DETAIL_CACHE.get(letterSeq)!;
+
+  // 목록에서 찾고, 없으면 새로 생성해서 합류
+  let found = ALL_HEAVEN_LETTERS.find((d) => d.letterSeq === letterSeq);
+  if (!found) {
+    found = makeHeavenLetterDetail(letterSeq);
+    ALL_HEAVEN_LETTERS.push(found);
+    ALL_HEAVEN_LETTERS.sort(byWriteDesc);
+  }
+
+  DETAIL_CACHE.set(letterSeq, found);
+  return found;
+}
+
+export function heavenLetterDetailResponse(letterSeq: number): HeavenLetterDetailResponse {
+  return {
+    success: true,
+    code: 200,
+    message: "하늘나라 편지 상세 조회 성공",
+    data: getHeavenLetterDetail(letterSeq),
+  };
+}

--- a/src/mocks/data/heaven.ts
+++ b/src/mocks/data/heaven.ts
@@ -63,8 +63,7 @@ function heavenLetterDetail(seq?: number): HeavenLetterDetail {
   };
 }
 
-/* ---------- 목록/정렬/커서 페이징 (기존 유지) ---------- */
-/** 한 번만 생성해 재사용 */
+/** 전역 데이터셋 생성 및 정렬 */
 export const allHeavenLetters: HeavenLetterDetail[] = Array.from({ length: TOTAL }, () =>
   heavenLetterDetail(),
 );

--- a/src/mocks/data/heaven.ts
+++ b/src/mocks/data/heaven.ts
@@ -6,61 +6,30 @@ import type {
 } from "@/shared/api/letter-view/letter/types";
 import type { Comment, CommentPagination } from "@/shared/api/recipient-view/comment/types";
 import { createCursorPagination, createDateDescSorter } from "@/mocks/utils/paginate";
+import { commentPoolManager } from "@/mocks/utils/commentPool";
 
 // 시드 고정
 faker.seed(42);
 
-/** 전역 데이터: HeavenLetterDetail[] 만 사용 */
 const TOTAL = 300;
 
 /** 댓글 풀 + 슬라이스 */
-const commentsByLetter = new Map<number, Comment[]>();
-
-function LetterCommentPool(letterSeq: number, poolSize = 10): Comment[] {
-  if (!commentsByLetter.has(letterSeq)) {
-    const pool: Comment[] = Array.from({ length: poolSize }, () => ({
-      commentSeq: faker.number.int({ min: 1, max: 1000000 }),
-      letterSeq, // 편지 기준
-      commentWriter: faker.person.fullName(),
-      contents: faker.lorem.sentences({ min: 1, max: 3 }),
-      writeTime: faker.date.past().toISOString(),
-    })).sort((a, b) => new Date(b.writeTime!).getTime() - new Date(a.writeTime!).getTime());
-    commentsByLetter.set(letterSeq, pool);
-  }
-  return commentsByLetter.get(letterSeq)!;
-}
-
-function sliceLetterComments(letterSeq: number, size = 3, cursorSeq?: number): CommentPagination {
-  const pool = LetterCommentPool(letterSeq);
-
-  let start = 0;
-  if (cursorSeq) {
-    const idx = pool.findIndex((c) => c.commentSeq === cursorSeq);
-    start = idx >= 0 ? idx + 1 : pool.length;
-  }
-
-  const page = pool.slice(start, start + size);
-  const hasNext = start + size < pool.length;
-  const nextCursor = hasNext && page.length ? page.at(-1)!.commentSeq : 0;
-
-  return {
-    content: page,
-    comments: page,
-    commentHasNext: hasNext,
-    commentNextCursor: nextCursor,
-  };
-}
-
-/** 커서 기반 */
 export function commentPagination(
   letterSeq: number,
   size = 3,
   cursorSeq?: number,
 ): CommentPagination {
-  return sliceLetterComments(letterSeq, size, cursorSeq);
+  return commentPoolManager.createAndSlice(
+    `letter_${letterSeq}`,
+    50,
+    "letterSeq",
+    letterSeq,
+    size,
+    cursorSeq,
+  );
 }
 
-/* ------------------------- 편지 상세 생성 ------------------------- */
+/** 편지 상세 생성  */
 function heavenLetterDetail(seq?: number): HeavenLetterDetail {
   const writeDt = faker.date.past();
   const anonymityFlag = faker.helpers.arrayElement<"Y" | "N">(["Y", "N"]);

--- a/src/mocks/data/heaven.ts
+++ b/src/mocks/data/heaven.ts
@@ -5,6 +5,7 @@ import type {
   HeavenLetterDetailResponse,
 } from "@/shared/api/letter-view/letter/types";
 import type { Comment, CommentPagination } from "@/shared/api/recipient-view/comment/types";
+import { createCursorPagination, createDateDescSorter } from "@/mocks/utils/paginate";
 
 // 시드 고정
 faker.seed(42);
@@ -99,39 +100,15 @@ export const allHeavenLetters: HeavenLetterDetail[] = Array.from({ length: TOTAL
   heavenLetterDetail(),
 );
 
-/** writeTime 내림차순 → 같은 날짜면 letterSeq 내림차순 */
-const byWriteDesc = (a: HeavenLetterDetail, b: HeavenLetterDetail) => {
-  const ta = new Date(a.writeTime).getTime();
-  const tb = new Date(b.writeTime).getTime();
-  if (ta !== tb) return tb - ta;
-  return b.letterSeq - a.letterSeq;
-};
+/** writeTime 정렬 유틸 사용 */
+const sorter = createDateDescSorter(
+  (item: HeavenLetterDetail) => item.writeTime,
+  (item: HeavenLetterDetail) => item.letterSeq,
+);
 
-allHeavenLetters.sort(byWriteDesc);
+allHeavenLetters.sort(sorter);
 
-/** 커서 페이징 (편지 목록용) */
-function sliceByCursor(
-  size: number,
-  cursor?: { seq: number; date: string }, // date는 YYYY-MM-DD
-) {
-  let start = 0;
-  if (cursor) {
-    const idx = allHeavenLetters.findIndex(
-      (d) => d.letterSeq === cursor.seq && d.writeTime.slice(0, 10) === cursor.date,
-    );
-    start = idx >= 0 ? idx + 1 : allHeavenLetters.length;
-  }
-
-  const window = allHeavenLetters.slice(start, start + size);
-  const hasNext = start + size < allHeavenLetters.length;
-  const last = window.at(-1);
-  const nextCursor =
-    hasNext && last ? { cursor: last.letterSeq, date: last.writeTime.slice(0, 10) } : null;
-
-  return { window, hasNext, nextCursor, totalCount: allHeavenLetters.length };
-}
-
-/** 목록 응답: LetterCardData[] 로 바로 내려줌 */
+/** 편지 목록 응답 - 페이지네이션 유틸  */
 export function heavenLetterListResponse(params?: {
   size?: number;
   cursorSeq?: number;
@@ -156,7 +133,19 @@ export function heavenLetterListResponse(params?: {
       ? { seq: params.cursorSeq, date: params.cursorDate }
       : undefined;
 
-  const { window, hasNext, nextCursor, totalCount } = sliceByCursor(size, cursor);
+  // 페이지네이션 유틸 사용
+  const {
+    content: window,
+    hasNext,
+    nextCursor,
+    totalCount,
+  } = createCursorPagination(
+    allHeavenLetters,
+    size,
+    cursor,
+    (item) => item.letterSeq,
+    (item) => item.writeTime,
+  );
 
   const items = window.map((d) => ({
     letterSeq: d.letterSeq,
@@ -176,7 +165,7 @@ export function heavenLetterListResponse(params?: {
   };
 }
 
-/** 상세: HeavenLetterDetail 그대로 사용 */
+/** 상세 조회 캐시 */
 const DETAIL_CACHE = new Map<number, HeavenLetterDetail>();
 
 export function getHeavenLetterDetail(letterSeq: number): HeavenLetterDetail {
@@ -187,7 +176,7 @@ export function getHeavenLetterDetail(letterSeq: number): HeavenLetterDetail {
   if (!found) {
     found = heavenLetterDetail(letterSeq);
     allHeavenLetters.push(found);
-    allHeavenLetters.sort(byWriteDesc);
+    allHeavenLetters.sort(sorter);
   }
 
   DETAIL_CACHE.set(letterSeq, found);
@@ -203,7 +192,7 @@ export function heavenLetterDetailResponse(
   const size = opts?.commentSize ?? 3;
   const cursor = opts?.commentCursor;
 
-  // 댓글 페이지네이션은 항상 새로 계산해서 내려줌
+  // 댓글 페이지네이션은 항상 새로 계산
   const withComments: HeavenLetterDetail = {
     ...base,
     cursorCommentPaginationResponse: commentPagination(letterSeq, size, cursor),

--- a/src/mocks/data/heaven.ts
+++ b/src/mocks/data/heaven.ts
@@ -15,7 +15,7 @@ const TOTAL = 300;
 /** 댓글 풀 + 슬라이스 */
 const commentsByLetter = new Map<number, Comment[]>();
 
-function LetterCommentPool(letterSeq: number, poolSize = 80): Comment[] {
+function LetterCommentPool(letterSeq: number, poolSize = 10): Comment[] {
   if (!commentsByLetter.has(letterSeq)) {
     const pool: Comment[] = Array.from({ length: poolSize }, () => ({
       commentSeq: faker.number.int({ min: 1, max: 1000000 }),

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,10 @@
 import { http, HttpResponse } from "msw";
 import { donorListResponse, donorDetailResponse } from "@/mocks/data/Memorial";
-import { heavenLetterDetailResponse, heavenLetterListResponse } from "@/mocks/data/heaven";
+import {
+  heavenLetterDetailResponse,
+  heavenLetterListResponse,
+  commentPagination,
+} from "@/mocks/data/heaven";
 
 export const handlers = [
   // 기증자 목록 조회
@@ -48,5 +52,21 @@ export const handlers = [
     const letterSeq = Number(params.letterSeq);
     const body = heavenLetterDetailResponse(letterSeq);
     return HttpResponse.json(body, { status: 200 });
+  }),
+
+  // 하늘나라 편지 댓글 더보기
+  http.get("*/heavenLetters/:letterSeq/comments", ({ request, params }) => {
+    const url = new URL(request.url);
+    const size = Number(url.searchParams.get("size")) || 3;
+    const cursor = url.searchParams.get("commentCursor");
+    const cursorSeq = cursor ? Number(cursor) : undefined;
+
+    const letterSeq = Number(params.letterSeq);
+    const data = commentPagination(letterSeq, size, cursorSeq);
+
+    return HttpResponse.json(
+      { success: true, code: 200, message: "댓글 조회 성공", data },
+      { status: 200 },
+    );
   }),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,7 +1,8 @@
 import { http, HttpResponse } from "msw";
-import { donorListResponse } from "@/mocks/data/Memorial";
+import { donorListResponse, donorDetailResponse } from "@/mocks/data/Memorial";
 
 export const handlers = [
+  // 기증자 목록 조회
   http.get("*/remembrance/search", ({ request }) => {
     const url = new URL(request.url);
 
@@ -15,6 +16,13 @@ export const handlers = [
       cursorDate: cursorDate ?? undefined,
     });
 
+    return HttpResponse.json(body, { status: 200 });
+  }),
+
+  // 기증자 상세 조회
+  http.get("*/remembrance/:donateSeq", ({ params }) => {
+    const donateSeq = Number(params.donateSeq);
+    const body = donorDetailResponse(donateSeq);
     return HttpResponse.json(body, { status: 200 });
   }),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,20 @@
+import { http, HttpResponse } from "msw";
+import { donorListResponse } from "@/mocks/data/Memorial";
+
+export const handlers = [
+  http.get("*/remembrance/search", ({ request }) => {
+    const url = new URL(request.url);
+
+    const size = Number(url.searchParams.get("size") ?? "30");
+    const cursorSeq = url.searchParams.get("cursor");
+    const cursorDate = url.searchParams.get("date");
+
+    const body = donorListResponse({
+      size,
+      cursorSeq: cursorSeq ? Number(cursorSeq) : undefined,
+      cursorDate: cursorDate ?? undefined,
+    });
+
+    return HttpResponse.json(body, { status: 200 });
+  }),
+];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { donorListResponse, donorDetailResponse } from "@/mocks/data/Memorial";
+import { heavenLetterDetailResponse, heavenLetterListResponse } from "@/mocks/data/heaven";
 
 export const handlers = [
   // 기증자 목록 조회
@@ -23,6 +24,29 @@ export const handlers = [
   http.get("*/remembrance/:donateSeq", ({ params }) => {
     const donateSeq = Number(params.donateSeq);
     const body = donorDetailResponse(donateSeq);
+    return HttpResponse.json(body, { status: 200 });
+  }),
+
+  // 하늘나라 편지 목록 조회
+  http.get("*/heavenLetters", ({ request }) => {
+    const url = new URL(request.url);
+    const size = Number(url.searchParams.get("size") ?? "30");
+    const cursorSeq = url.searchParams.get("cursor");
+    const cursorDate = url.searchParams.get("date"); // YYYY-MM-DD
+
+    const body = heavenLetterListResponse({
+      size,
+      cursorSeq: cursorSeq ? Number(cursorSeq) : undefined,
+      cursorDate: cursorDate ?? undefined,
+    });
+
+    return HttpResponse.json(body, { status: 200 });
+  }),
+
+  // 하늘나라 편지 상세 조회
+  http.get("*/heavenLetters/:letterSeq", ({ params }) => {
+    const letterSeq = Number(params.letterSeq);
+    const body = heavenLetterDetailResponse(letterSeq);
     return HttpResponse.json(body, { status: 200 });
   }),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,9 @@
 import { http, HttpResponse } from "msw";
-import { donorListResponse, donorDetailResponse } from "@/mocks/data/Memorial";
+import {
+  donorListResponse,
+  donorDetailResponse,
+  makeCommentPagination,
+} from "@/mocks/data/Memorial";
 import {
   heavenLetterDetailResponse,
   heavenLetterListResponse,
@@ -29,6 +33,22 @@ export const handlers = [
     const donateSeq = Number(params.donateSeq);
     const body = donorDetailResponse(donateSeq);
     return HttpResponse.json(body, { status: 200 });
+  }),
+
+  // 기증자 댓글 더보기
+  http.get("*/remembrance/:donateSeq/comment", ({ request, params }) => {
+    const url = new URL(request.url);
+    const size = Number(url.searchParams.get("size")) || 3;
+    const cursor = url.searchParams.get("cursor");
+    const cursorSeq = cursor ? Number(cursor) : undefined;
+
+    const donateSeq = Number(params.donateSeq);
+    const data = makeCommentPagination(donateSeq, size, cursorSeq);
+
+    return HttpResponse.json(
+      { success: true, code: 200, message: "댓글 조회 성공", data },
+      { status: 200 },
+    );
   }),
 
   // 하늘나라 편지 목록 조회

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,6 +3,7 @@ import {
   donorListResponse,
   donorDetailResponse,
   makeCommentPagination,
+  makeHeavenLetterPagination,
 } from "@/mocks/data/Memorial";
 import {
   heavenLetterDetailResponse,
@@ -47,6 +48,22 @@ export const handlers = [
 
     return HttpResponse.json(
       { success: true, code: 200, message: "댓글 조회 성공", data },
+      { status: 200 },
+    );
+  }),
+
+  // 기증자 편지 더보기
+  http.get("*/heavenLetters/:letterSeq/remembrance", ({ request, params }) => {
+    const url = new URL(request.url);
+    const size = Number(url.searchParams.get("size")) || 3;
+    const cursor = url.searchParams.get("cursor");
+    const cursorSeq = cursor ? Number(cursor) : undefined;
+    const donateSeq = Number(params.letterSeq);
+
+    const data = makeHeavenLetterPagination(donateSeq, size, cursorSeq);
+
+    return HttpResponse.json(
+      { success: true, code: 200, message: "편지 조회 성공", data },
       { status: 200 },
     );
   }),

--- a/src/mocks/utils/commentPool.ts
+++ b/src/mocks/utils/commentPool.ts
@@ -1,0 +1,65 @@
+import { fakerKO as faker } from "@faker-js/faker";
+import type { Comment, CommentPagination } from "@/shared/api/recipient-view/comment/types";
+
+export class CommentPoolManager {
+  private pools = new Map<string, Comment[]>();
+
+  // 풀 생성 또는 가져오기
+  getOrCreatePool(
+    key: string,
+    poolSize: number,
+    keyField: "letterSeq" | "donateSeq",
+    keyValue: number,
+  ): Comment[] {
+    if (!this.pools.has(key)) {
+      const pool: Comment[] = Array.from({ length: poolSize }, () => ({
+        commentSeq: faker.number.int({ min: 1, max: 1000000 }),
+        [keyField]: keyValue, // 동적 속성 할당
+        commentWriter: faker.person.fullName(),
+        contents: faker.lorem.sentences({ min: 1, max: 3 }),
+        writeTime: faker.date.past().toISOString(),
+      })).sort((a, b) => new Date(b.writeTime!).getTime() - new Date(a.writeTime!).getTime()); // 최신순 정렬
+
+      this.pools.set(key, pool);
+    }
+    return this.pools.get(key)!;
+  }
+
+  // 커서 기반으로 댓글 슬라이스
+  sliceComments(key: string, size: number, cursorSeq?: number): CommentPagination {
+    const pool = this.pools.get(key) || [];
+
+    let start = 0;
+    if (cursorSeq) {
+      const idx = pool.findIndex((c) => c.commentSeq === cursorSeq);
+      start = idx >= 0 ? idx + 1 : pool.length;
+    }
+
+    const page = pool.slice(start, start + size);
+    const hasNext = start + size < pool.length;
+    const nextCursor = hasNext && page.length ? page.at(-1)!.commentSeq : 0;
+
+    return {
+      content: page,
+      comments: page,
+      commentHasNext: hasNext,
+      commentNextCursor: nextCursor,
+    };
+  }
+
+  // 한 번에 풀 생성하고 슬라이스
+  createAndSlice(
+    key: string,
+    poolSize: number,
+    keyField: "letterSeq" | "donateSeq",
+    keyValue: number,
+    size: number,
+    cursorSeq?: number,
+  ): CommentPagination {
+    this.getOrCreatePool(key, poolSize, keyField, keyValue);
+    return this.sliceComments(key, size, cursorSeq);
+  }
+}
+
+// 싱글톤 인스턴스 (모든 곳에서 같은 풀 공유)
+export const commentPoolManager = new CommentPoolManager();

--- a/src/mocks/utils/letterPool.ts
+++ b/src/mocks/utils/letterPool.ts
@@ -1,0 +1,59 @@
+import { fakerKO as faker } from "@faker-js/faker";
+import type { HeavenLetter, HeavenLetterPagination } from "@/shared/api/members-view/letter/types";
+
+export class LetterPoolManager {
+  private pools = new Map<string, HeavenLetter[]>();
+
+  // 풀 생성 (donor 단위)
+  getOrCreatePool(donateSeq: number, poolSize: number): HeavenLetter[] {
+    const key = `donor-${donateSeq}`;
+    if (!this.pools.has(key)) {
+      const pool: HeavenLetter[] = Array.from({ length: poolSize }, () => ({
+        letterSeq: faker.number.int({ min: 1, max: 1000000 }),
+        donateSeq,
+        letterTitle: faker.lorem.words(3),
+        readCount: faker.number.int({ min: 0, max: 100 }),
+        writeTime: faker.date.past().toISOString().slice(0, 10),
+      })).sort((a, b) => new Date(b.writeTime).getTime() - new Date(a.writeTime).getTime());
+
+      this.pools.set(key, pool);
+    }
+    return this.pools.get(key)!;
+  }
+
+  // 커서 기반 슬라이스
+  sliceLetters(donateSeq: number, size: number, cursorSeq?: number): HeavenLetterPagination {
+    const pool = this.pools.get(`donor-${donateSeq}`) ?? [];
+
+    let start = 0;
+    if (cursorSeq) {
+      const idx = pool.findIndex((l) => l.letterSeq === cursorSeq);
+      start = idx >= 0 ? idx + 1 : pool.length;
+    }
+
+    const page = pool.slice(start, start + size);
+    const hasNext = start + size < pool.length;
+    const nextCursor = hasNext && page.length ? page.at(-1)!.letterSeq : 0;
+
+    return {
+      content: page,
+      hasNext,
+      nextCursor,
+      totalCount: pool.length,
+    };
+  }
+
+  // 한 번에 풀 생성 + 슬라이스
+  createAndSlice(
+    donateSeq: number,
+    poolSize: number,
+    size: number,
+    cursorSeq?: number,
+  ): HeavenLetterPagination {
+    this.getOrCreatePool(donateSeq, poolSize);
+    return this.sliceLetters(donateSeq, size, cursorSeq);
+  }
+}
+
+// 싱글톤 인스턴스
+export const letterPoolManager = new LetterPoolManager();

--- a/src/mocks/utils/paginate.ts
+++ b/src/mocks/utils/paginate.ts
@@ -1,0 +1,54 @@
+export interface CursorInfo {
+  seq: number;
+  date: string;
+}
+
+export interface PaginationResult<T> {
+  content: T[];
+  hasNext: boolean;
+  nextCursor: { cursor: number; date: string } | null;
+  totalCount: number;
+}
+
+// 페이지네이션
+export function createCursorPagination<T>(
+  items: T[],
+  size: number,
+  cursor: CursorInfo | undefined,
+  getSeq: (item: T) => number,
+  getDate: (item: T) => string,
+): PaginationResult<T> {
+  let start = 0; // 첫 페이지
+
+  // 커서를 찾으면 idx+1 부터, 없으면 빈 결과 반환
+  if (cursor) {
+    const idx = items.findIndex(
+      (item) => getSeq(item) === cursor.seq && getDate(item) === cursor.date,
+    );
+    start = idx >= 0 ? idx + 1 : items.length;
+  }
+
+  // 데이터 슬라이싱 및 다음 커서 계산
+  const content = items.slice(start, start + size);
+  const hasNext = start + size < items.length;
+  const last = content.at(-1); // 현재 페이지의 마지막 아이템
+  const nextCursor =
+    hasNext && last
+      ? {
+          cursor: getSeq(last),
+          date: getDate(last),
+        }
+      : null;
+
+  return { content, hasNext, nextCursor, totalCount: items.length };
+}
+
+// 정렬 유틸
+export const createDateDescSorter =
+  <T>(getDate: (item: T) => string, getSeq: (item: T) => number) =>
+  (a: T, b: T) => {
+    const ta = new Date(getDate(a)).getTime();
+    const tb = new Date(getDate(b)).getTime();
+    if (ta !== tb) return tb - ta; // 날짜 내림차순
+    return getSeq(b) - getSeq(a); // 같은 날짜면 seq 내림차순
+  };


### PR DESCRIPTION
## 📌 PR 제목
- MSW + faker.js 기반 mock 서버 리팩토링

## 📝 변경사항
- [x] 기존 백엔드 서버 다운 -> MSW + faker.js로 mock API 구성
- [x] 서비스의 핵심인 기증자 추모관 & 하늘나라 편지를 mock 데이터 및 API로 대체

## 🙋 기타 코멘트
- 백엔드 서버 다운으로 인해 임시용으로 mock 데이터를 사용하였습니다.
- 현재는 기증자 추모관과 하늘나라 편지만 msw로 대체한 상황입니다.
